### PR TITLE
Limit clamp mix sliders to overlay shader

### DIFF
--- a/Assets/Dither3D/Dither3DOverlay.shader
+++ b/Assets/Dither3D/Dither3DOverlay.shader
@@ -14,6 +14,10 @@ Shader "Dither 3D/Overlay"
         _SizeVariability ("Dot Size Variability", Range(0,1)) = 0
         _Contrast ("Dot Contrast", Range(0,2)) = 1
         _StretchSmoothness ("Stretch Smoothness", Range(0,2)) = 1
+        _BlackPoint ("Black Dither Range", Range(0,0.5)) = 0.33
+        _WhitePoint ("White Dither Range", Range(0,0.5)) = 0.33
+        _BlackClampMix ("Black Clamp Mix", Range(0,1)) = 0
+        _WhiteClampMix ("White Clamp Mix", Range(0,1)) = 0
 
         [Header(Blend Mode)]
         _BlendMode ("Blend Mode", Int) = 0
@@ -46,6 +50,57 @@ Shader "Dither 3D/Overlay"
             sampler2D _GrabTexture;
             int _BlendMode;
 
+            fixed ProcessDitherChannel(fixed c, float2 uv, float4 screenPos, float2 dx, float2 dy)
+            {
+                if (c < _BlackPoint)
+                {
+                    float b = c / max(_BlackPoint, 1e-5);
+                    fixed d = GetDither3D_(uv, screenPos, dx, dy, b).x;
+                    return c * (_BlackClampMix + (1 - _BlackClampMix) * d);
+                }
+                else if (c > 1.0 - _WhitePoint)
+                {
+                    float b = (c - (1.0 - _WhitePoint)) / max(_WhitePoint, 1e-5);
+                    fixed d = GetDither3D_(uv, screenPos, dx, dy, b).x;
+                    return c + (1 - c) * d * (1 - _WhiteClampMix);
+                }
+                else
+                {
+                    return c;
+                }
+            }
+
+            fixed4 GetOverlayDitherColor_(float2 uv_DitherTex, float4 screenPos, float2 dx, float2 dy, fixed4 color)
+            {
+                color.rgb = saturate(color.rgb * _InputExposure + _InputOffset);
+
+                #ifdef DITHERCOL_GRAYSCALE
+                    fixed brightness = GetGrayscale(color);
+                    brightness = ProcessDitherChannel(brightness, uv_DitherTex, screenPos, dx, dy);
+                    color.rgb = brightness;
+                #elif DITHERCOL_RGB
+                    color.r = ProcessDitherChannel(color.r, uv_DitherTex, screenPos, dx, dy);
+                    color.g = ProcessDitherChannel(color.g, uv_DitherTex, screenPos, dx, dy);
+                    color.b = ProcessDitherChannel(color.b, uv_DitherTex, screenPos, dx, dy);
+                #elif DITHERCOL_CMYK
+                    fixed4 cmyk = RGBtoCMYK(color.rgb);
+                    cmyk.x = ProcessDitherChannel(cmyk.x, RotateUV(uv_DitherTex, float2(0.966, 0.259)), screenPos, dx, dy);
+                    cmyk.y = ProcessDitherChannel(cmyk.y, RotateUV(uv_DitherTex, float2(0.259, 0.966)), screenPos, dx, dy);
+                    cmyk.z = ProcessDitherChannel(cmyk.z, RotateUV(uv_DitherTex, float2(1.000, 0.000)), screenPos, dx, dy);
+                    cmyk.w = ProcessDitherChannel(cmyk.w, RotateUV(uv_DitherTex, float2(0.707, 0.707)), screenPos, dx, dy);
+                    color.rgb = CMYKtoRGB(cmyk);
+                #endif
+
+                return color;
+            }
+
+            fixed4 GetOverlayDitherColor(float2 uv_DitherTex, float4 screenPos, fixed4 color)
+            {
+                float2 dx = ddx(uv_DitherTex);
+                float2 dy = ddy(uv_DitherTex);
+                return GetOverlayDitherColor_(uv_DitherTex, screenPos, dx, dy, color);
+            }
+
             struct appdata
             {
                 float4 vertex : POSITION;
@@ -71,7 +126,7 @@ Shader "Dither 3D/Overlay"
             fixed4 frag (v2f i) : SV_Target
             {
                 fixed4 baseCol = tex2Dproj(_GrabTexture, UNITY_PROJ_COORD(i.screenPos));
-                fixed4 ditherCol = GetDither3DColor(i.uv, i.screenPos, baseCol);
+                fixed4 ditherCol = GetOverlayDitherColor(i.uv, i.screenPos, baseCol);
                 fixed4 result;
                 if (_BlendMode == 1)
                 {


### PR DESCRIPTION
## Summary
- keep black/white dither range and clamp mix sliders only on the overlay shader
- revert shared include and other shaders to original behavior so only overlay uses new channel clamping logic

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689828ccc1f48327b22d9a89f9edc76f